### PR TITLE
AI-5487 - Add Puppet5 compat when the catalog does not compile

### DIFF
--- a/src/collectd_puppet/__init__.py
+++ b/src/collectd_puppet/__init__.py
@@ -78,7 +78,7 @@ def read_func():
     # This type is always populated, even on a compilation error
     times = [
         data['time']['last_run'],
-        1 if 'resources' in data else 0,
+        1 if 'config_retrieval' in data['time'] else 0,
     ]
     val = collectd.Values(plugin='puppet',)
     val.type = 'puppet_time'

--- a/src/collectd_puppet/__init__.py
+++ b/src/collectd_puppet/__init__.py
@@ -88,8 +88,8 @@ def read_func():
 
     # puppet_run type
     # this type is not populated in certain cases, e.g compilation
-    # error.
-    if 'resources' in data:
+    # error (zero resources).
+    if 'resources' in data and data['resources']['total'] > 0:
         run = [
             data['resources']['total'],
             data['resources']['changed'],


### PR DESCRIPTION
Check the commit messages for more detailed information.

Current scenario if a compilation fails:

```
# collectdctl getval foreman31.cern.ch/puppet/puppet_time
last_run=1.556177e+09
compiled=1.000000e+00
# collectdctl getval foreman31.cern.ch/puppet/puppet_run
ERROR: Server error: No such value.
```

and

```
[2019-04-24 09:20:52] Unhandled python exception in read callback: KeyError: 'config_retrieval'
[2019-04-24 09:20:52] Traceback (most recent call last):
[2019-04-24 09:20:52]   File "/usr/lib/python2.7/site-packages/collectd_puppet/__init__.py", line 91, in read_func
    data['time']['config_retrieval'],
[2019-04-24 09:20:52] KeyError: 'config_retrieval'
[2019-04-24 09:20:52] read-function of plugin `python.collectd_puppet' failed. Will suspend it for 120.000 seconds.
```

With the patch:

```
# collectdctl getval foreman31.cern.ch/puppet/puppet_time
last_run=1.556177e+09
compiled=0.000000e+00
# collectdctl getval foreman31.cern.ch/puppet/puppet_run
ERROR: Server error: No such value.
```

and of course no crash.