### PR TITLE
AI-5511 - Flatten values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ it.
 These are the values that are currently being dispatched:
 
 * puppet/boolean-compiled (flag denoting if the catalog compiled (1 or 0))
-* puppet/duration-config_retrieval
-* puppet/duration-total_time
+* puppet/seconds-config_retrieval
+* puppet/seconds-total_time
 * puppet/resources-changed
 * puppet/resources-corrective_change
 * puppet/resources-failed

--- a/README.rst
+++ b/README.rst
@@ -18,43 +18,33 @@ Configuration
      PATH "/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml"
    </Plugin>
 
-Collectd Types
+Generated data
 --------------
 
 The plugin parses
 ``/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml`` and reports
-two collectd types.
+several single values extracted from there.
 
 It will only send data if there has been a Puppet run after the last
 time Collectd polled. This is monitored using a state file located in
 ``/var/lib/collectd/puppet.state``. To force a data point just delete
 it.
 
-puppet_run
-~~~~~~~~~~
+These are the values that are currently being dispatched:
 
-A count of numbers of resources and duration of agent run and
-config_retrieval
-
--  total
--  changed
--  corrective_change
--  failed
--  failed_to_restart
--  out_of_sync
--  restarted
--  scheduled
--  skipped
--  time
--  config_retrieval
-
-puppet_time
-^^^^^^^^^^^
-
-All in units of seconds
-
--  last_run - epoch of last puppet run (seconds).
--  compiled - flag denoting if the catalog compiled (1 or 0).
+* puppet/boolean-compiled (flag denoting if the catalog compiled (1 or 0))
+* puppet/duration-config_retrieval
+* puppet/duration-total_time
+* puppet/resources-changed
+* puppet/resources-corrective_change
+* puppet/resources-failed
+* puppet/resources-failed_to_restart
+* puppet/resources-out_of_sync
+* puppet/resources-restarted
+* puppet/resources-scheduled
+* puppet/resources-skipped
+* puppet/resources-total
+* puppet/time_ref-last_run (epoch of last puppet run (seconds))
 
 Authors
 -------
@@ -72,4 +62,4 @@ Apache-II License
 Development notes
 -----------------
 
-Don't forget to bump the ``schema_version`` if you modify the types.
+Don't forget to bump the ``schema_version`` if you modify the data format.

--- a/resources/puppet_types.db
+++ b/resources/puppet_types.db
@@ -1,3 +1,4 @@
 # Types for the collectd puppet plugin
 resources value:GAUGE:0:U
+seconds value:GAUGE:0:U
 boolean value:GAUGE:0:1

--- a/resources/puppet_types.db
+++ b/resources/puppet_types.db
@@ -1,7 +1,3 @@
-
 # Types for the collectd puppet plugin
-# puppet_run is the count of resourcs, e.g total, failed, ... within a puppet run and also the duration of the puppet run as well as the config_retreival time.
-# puppet_time is all in seconds and is the epoch of the last_run , time since last run in seconds.
-
-puppet_run total:GAUGE:0:u changed:GAUGE:0:u corrective_change:GAUGE:0:u failed:GAUGE:0:u failed_to_restart:GAUGE:0:u out_of_sync:GAUGE:0:u restarted:GAUGE:0:u scheduled:GAUGE:0:u skipped:GAUGE:0:u time:GAUGE:0:u config_retrieval:GAUGE:0:u
-puppet_time last_run:GAUGE:0:u compiled:GAUGE:0:1
+resources value:GAUGE:0:U
+boolean value:GAUGE:0:1

--- a/src/collectd_puppet/__init__.py
+++ b/src/collectd_puppet/__init__.py
@@ -35,7 +35,7 @@ PATH = "/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml"
 STATE = "/var/lib/collectd/puppet.state"
 MAX_RETENTION = 60*60*6
 
-META = {'schema_version': 1}
+META = {'schema_version': 2}
 
 def config_func(config):
     """ accept configuration from collectd """
@@ -74,40 +74,34 @@ def read_func():
         except yaml.YAMLError as exc:
             print(exc)
 
-    # puppet_time type.
-    # This type is always populated, even on a compilation error
-    times = [
-        data['time']['last_run'],
-        1 if 'config_retrieval' in data['time'] else 0,
+    # This group of values is always populated, even on a compilation error
+    sources = [
+        ('last_run', 'time_ref', data['time']['last_run']),
+        ('compiled', 'boolean', 1 if 'config_retrieval' in data['time'] else 0),
     ]
-    val = collectd.Values(plugin='puppet',)
-    val.type = 'puppet_time'
-    val.meta = META
-    val.values = times
-    val.dispatch(interval=MAX_RETENTION)
 
-    # puppet_run type
-    # this type is not populated in certain cases, e.g compilation
-    # error (zero resources).
+    # This group of values is only populated when the compilation is successful
+    # and the catalog has resources.
     if 'resources' in data and data['resources']['total'] > 0:
-        run = [
-            data['resources']['total'],
-            data['resources']['changed'],
-            data['resources']['corrective_change'],
-            data['resources']['failed'],
-            data['resources']['failed_to_restart'],
-            data['resources']['out_of_sync'],
-            data['resources']['restarted'],
-            data['resources']['scheduled'],
-            data['resources']['skipped'],
-            data['time']['total'],
-            data['time']['config_retrieval'],
-        ]
-        val = collectd.Values(plugin='puppet',)
-        val.type = 'puppet_run'
-        val.meta = META
-        val.values = run
-        val.dispatch(interval=MAX_RETENTION)
+        sources.extend([
+            ('total', 'resources', data['resources']['total']),
+            ('changed', 'resources', data['resources']['changed']),
+            ('corrective_change', 'resources', data['resources']['corrective_change']),
+            ('failed', 'resources', data['resources']['failed']),
+            ('failed_to_restart', 'resources', data['resources']['failed_to_restart']),
+            ('out_of_sync', 'resources', data['resources']['out_of_sync']),
+            ('restarted', 'resources', data['resources']['restarted']),
+            ('scheduled', 'resources', data['resources']['scheduled']),
+            ('skipped', 'resources', data['resources']['skipped']),
+            ('total_time', 'duration', data['time']['total']),
+            ('config_retrieval', 'duration', data['time']['config_retrieval']),
+        ])
+
+    for type_instance, _type, value in sources:
+        collectd.Values(plugin='puppet',
+                        type=_type,
+                        type_instance=type_instance,
+                        meta=META).dispatch(values=[value], interval=MAX_RETENTION)
 
 collectd.register_config(config_func)
 collectd.register_read(read_func)

--- a/src/collectd_puppet/__init__.py
+++ b/src/collectd_puppet/__init__.py
@@ -93,8 +93,8 @@ def read_func():
             ('restarted', 'resources', data['resources']['restarted']),
             ('scheduled', 'resources', data['resources']['scheduled']),
             ('skipped', 'resources', data['resources']['skipped']),
-            ('total_time', 'duration', data['time']['total']),
-            ('config_retrieval', 'duration', data['time']['config_retrieval']),
+            ('total_time', 'seconds', data['time']['total']),
+            ('config_retrieval', 'seconds', data['time']['config_retrieval']),
         ])
 
     for type_instance, _type, value in sources:


### PR DESCRIPTION
Instead of grouping values in two user-defined types, the plugin now emits one single value per metric. This was done to ease alarming using the threshold plugin and because it's the recommended direction to take by the Collectd developers.

Before:

```
# collectdctl listval | grep puppet
foo.bar.cern.ch/puppet/puppet_run
foo.bar.cern.ch/puppet/puppet_time
# collectdctl listval | grep puppet | xargs -n 1 collectdctl getval
total=6.590000e+02
changed=0.000000e+00
corrective_change=0.000000e+00
failed=0.000000e+00
failed_to_restart=0.000000e+00
out_of_sync=0.000000e+00
restarted=0.000000e+00
scheduled=0.000000e+00
skipped=0.000000e+00
time=4.492460e+01
config_retrieval=2.565432e+01
last_run=1.559914e+09
compiled=1.000000e+00
```

After:

```
# collectdctl listval | grep puppet
foo.bar.cern.ch/puppet/boolean-compiled
foo.bar.cern.ch/puppet/resources-changed
foo.bar.cern.ch/puppet/resources-corrective_change
foo.bar.cern.ch/puppet/resources-failed
foo.bar.cern.ch/puppet/resources-failed_to_restart
foo.bar.cern.ch/puppet/resources-out_of_sync
foo.bar.cern.ch/puppet/resources-restarted
foo.bar.cern.ch/puppet/resources-scheduled
foo.bar.cern.ch/puppet/resources-skipped
foo.bar.cern.ch/puppet/resources-total
foo.bar.cern.ch/puppet/seconds-config_retrieval
foo.bar.cern.ch/puppet/seconds-total_time
foo.bar.cern.ch/puppet/time_ref-last_run
# collectdctl listval | grep puppet | xargs -n 1 collectdctl getval
value=1.000000e+00
value=0.000000e+00
value=0.000000e+00
value=0.000000e+00
value=0.000000e+00
value=0.000000e+00
value=0.000000e+00
value=0.000000e+00
value=0.000000e+00
value=7.850000e+02
value=2.226057e+01
value=4.012161e+01
value=1.559915e+09
```