### PR TITLE
Change default path to last_run_summary.yaml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Configuration
      LogTraces true
      Interactive false
      Import "puppet"
-     PATH "/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml"
+     PATH "/opt/puppetlabs/puppet/public/last_run_summary.yaml"
      MaxRetention 21600
    </Plugin>
 
@@ -29,13 +29,8 @@ Generated data
 --------------
 
 The plugin parses by default
-``/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml`` and
+``/opt/puppetlabs/puppet/public/last_run_summary.yaml`` and
 reports several single values extracted from there.
-
-Take into account that this path has changed in Puppet7 and becomes
-``/opt/puppetlabs/puppet/public/last_run_summary.yaml`` so adjust your
-configuration accordingly depending on your Puppet version. This
-default will be switched once Puppet6 reaches EOL (expected Feb 2023).
 
 It will only send data if there has been a Puppet run after the last
 time Collectd polled. This is monitored using a state file located in

--- a/src/collectd_puppet/__init__.py
+++ b/src/collectd_puppet/__init__.py
@@ -21,7 +21,7 @@ To configure with collectd
   Interactive false
   Import "collectd_puppet"
   <Module "collectd_puppet">
-    path "/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml"
+    path "/opt/puppetlabs/puppet/public/last_run_summary.yaml"
     MaxRetention 21600
   </Module>
 </Plugin>
@@ -32,7 +32,7 @@ import time
 import collectd
 import yaml
 
-PATH = "/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml"
+PATH = "/opt/puppetlabs/puppet/public/last_run_summary.yaml"
 STATE = "/var/lib/collectd/puppet.state"
 MAX_RETENTION = 60*60*6
 


### PR DESCRIPTION
Puppet6 is dead, it makes sense to make the new path default.