### PR TITLE
Update usage of yaml load function

### DIFF
--- a/src/collectd_puppet/__init__.py
+++ b/src/collectd_puppet/__init__.py
@@ -79,7 +79,7 @@ def read_func():
 
     with open(PATH, 'r') as stream:
         try:
-            data = yaml.load(stream)
+            data = yaml.load(stream, Loader=yaml.Loader)
             with open(STATE, 'a'):
                 os.utime(STATE, None)
         except yaml.YAMLError as exc:


### PR DESCRIPTION
In Linux10 hosts the default pyyaml version 6.0.1 doesn't allow to load yaml without specifying the type of loader to use.

```
[2025-09-01 09:29:07] Unhandled python exception in read callback: TypeError: load() missing 1 required positional argument: 'Loader'
[2025-09-01 09:29:07] Traceback (most recent call last):
[2025-09-01 09:29:07]   File "/usr/lib/python3.12/site-packages/collectd_puppet/__init__.py", line 82, in read_func
    data = yaml.load(stream)
           ^^^^^^^^^^^^^^^^^
[2025-09-01 09:29:07] TypeError: load() missing 1 required positional argument: 'Loader'
[2025-09-01 09:29:07] read-function of plugin `python.collectd_puppet' failed. Will suspend it for 120.000 seconds.
```

This PR sets the yaml loader to the basic one, which should be eough for this use case.